### PR TITLE
[kjhonggg95] 2023. 11. 04

### DIFF
--- a/kjhonggg95/baekjoon/25710.cpp
+++ b/kjhonggg95/baekjoon/25710.cpp
@@ -1,0 +1,55 @@
+#include <bits/stdc++.h>
+#define fastio ios::sync_with_stdio(false), cin.tie(0), cout.tie(0)
+#define X first
+#define Y second
+using namespace std;
+using ll = long long;
+using pii = pair<int, int>;
+
+int n, ans;
+int freq[2000];
+bool used[1000000];
+
+int main()
+{
+    fastio;
+    cin >> n;
+    vector<int> v(n), nums;
+    for (int i = 0; i < n; i++)
+    {
+        cin >> v[i];
+        freq[v[i]]++;
+    }
+
+    for (int i = 1; i <= 999; i++)
+    {
+        if (freq[i] > 0)
+            nums.push_back(i);
+
+        if (freq[i] >= 2)
+            nums.push_back(i);
+    }
+
+    for (int i = 0; i < nums.size() - 1; i++)
+    {
+        for (int j = i + 1; j < nums.size(); j++)
+        {
+            int sum = nums[i] * nums[j];
+            
+            if (used[sum]) continue;
+            used[sum] = true;
+
+            int score = 0;
+
+            while (sum)
+            {
+                score += sum % 10;
+                sum /= 10;
+            }
+
+            ans = max(ans, score);
+        }
+    }
+
+    cout << ans << '\n';
+}


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
[25710번: 점수 계산](https://www.acmicpc.net/problem/25710)

## 🚿 풀이
오늘 본 현대오토에버 코테 1번 문제와 비슷해서 복기 겸 풀어봤다.
가장 쉬운 풀이는 배열을 이중for문 돌리면서 가능한 모든 경우의 수를 탐색하면 되겠지만 `n` 이 최대 `100,000` 이기 때문에 시간초과가 날 가능성이 있다.
그렇기 때문에 문제에서 주어진 다른 조건인 `a` 의 값의 범위를 이용해야 한다.

1. 입력을 받으면서 `freq` 배열에 `1 ~ 999` 의 숫자가 몇 번 나왔는지 카운트한다.
2. `freq` 배열을 돌면서 숫자가 한 번 나왔다면 `nums` 에 한 번, 두 번 이상 나왔다면 두 번 넣어준다. 
-> 두 원소를 선택하는 것이기 때문에 최대 두 개까지만 필요
4. 이렇게 만들어진 `nums` 의 최대 크기는 약 `2000`이다. 이제 이걸 가지고 이중for문을 돌면서 점수의 최댓값을 구하면 된다.
-> 동일한 두 원소의 곱의 점수는 항상 같기 때문에 한 번 나온 두 원소의 곱을 `used` 배열에 따로 체크해주어 중복 계산을 피할 수 있다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` c++
#include <bits/stdc++.h>
#define fastio ios::sync_with_stdio(false), cin.tie(0), cout.tie(0)
#define X first
#define Y second
using namespace std;
using ll = long long;
using pii = pair<int, int>;

int n, ans;
int freq[2000];
bool used[1000000];

int main()
{
    fastio;
    cin >> n;
    vector<int> v(n), nums;
    for (int i = 0; i < n; i++)
    {
        cin >> v[i];
        freq[v[i]]++;
    }

    for (int i = 1; i <= 999; i++)
    {
        if (freq[i] > 0)
            nums.push_back(i);

        if (freq[i] >= 2)
            nums.push_back(i);
    }

    for (int i = 0; i < nums.size() - 1; i++)
    {
        for (int j = i + 1; j < nums.size(); j++)
        {
            int sum = nums[i] * nums[j];
            
            if (used[sum]) continue;
            used[sum] = true;

            int score = 0;

            while (sum)
            {
                score += sum % 10;
                sum /= 10;
            }

            ans = max(ans, score);
        }
    }

    cout << ans << '\n';
}

```
