### PR TITLE
[kjhonggg95] 2023. 11. 06

### DIFF
--- a/kjhonggg95/baekjoon/19845.cpp
+++ b/kjhonggg95/baekjoon/19845.cpp
@@ -1,0 +1,44 @@
+#include <bits/stdc++.h>
+#define fastio ios::sync_with_stdio(false), cin.tie(0), cout.tie(0)
+#define X first
+#define Y second
+using namespace std;
+using ll = long long;
+using pii = pair<int, int>;
+
+int main()
+{
+    fastio;
+    int n, q;
+    cin >> n >> q;
+    vector<int> v(n+1);
+
+    // 중력의 영향을 받기 때문에 내림차순으로 입력이 들어온다
+    for(int i = 1;i<=n;i++)
+        cin >> v[i];
+    
+    while(q--)
+    {
+        int x, y;
+        cin >> x >> y;
+
+        int wcnt = v[y] - x + 1; // 가로방향 레이저
+        int hcnt = 0; // 세로방향 레이저 -> y층 이상에서 x 보다 크거나 같은 최대 층 구하기
+
+        int lo = y - 1, hi = n + 1;
+
+        while(lo + 1 < hi)
+        {
+            int mid = (lo + hi) / 2;
+
+            if(v[mid] >= x)
+                lo = mid;
+            else
+                hi = mid;
+        }
+
+        hcnt = lo - y + 1;
+
+        cout << max(0, wcnt + hcnt - 1) << '\n';
+    }
+}


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
[19845번: 넴모넴모 2020](https://www.acmicpc.net/problem/19845)

## 🚿 풀이
1) 가로 방향 레이저로 지울 수 있는 넴모
    * `y`층에 살고 있는 넴모 중 `x`칸 왼쪽에 있는 넴모를 제외한 수
    * `v[y] - x + 1`

<br/>

2) 세로 방향 레이저로 지울 수 있는 넴모
    * `y`층 이상에서 x 보다 크거나 같은 넴모들이 살고 있는 최대 층수
    * 이 부분을 완전탐색으로 구하려면 시간복잡도가 _O(N)_ 이다. `Q`와 `N`이 최대 _250,000_ 이므로 이분탐색으로 _O(logN)_ 으로 구하도록 하였다. --> _O(QlogN)_

<br/>

* 가로방향, 세로방향 레이저가 겹치는 부분에서 중복 카운트가 1 발생한다. 
  정답을 출력하는 부분에서 1을 빼주되, 0개의 넴모를 제거하는 경우 -1이 나오므로 이 경우 0으로 출력하도록 처리했다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

```  c++
#include <bits/stdc++.h>
#define fastio ios::sync_with_stdio(false), cin.tie(0), cout.tie(0)
#define X first
#define Y second
using namespace std;
using ll = long long;
using pii = pair<int, int>;

int main()
{
    fastio;
    int n, q;
    cin >> n >> q;
    vector<int> v(n+1);

    // 중력의 영향을 받기 때문에 내림차순으로 입력이 들어온다
    for(int i = 1;i<=n;i++)
        cin >> v[i];
    
    while(q--)
    {
        int x, y;
        cin >> x >> y;

        int wcnt = v[y] - x + 1; // 가로방향 레이저
        int hcnt = 0; // 세로방향 레이저 -> y층 이상에서 x 보다 큰 최대 층 구하기

        int lo = y - 1, hi = n + 1;

        while(lo + 1 < hi)
        {
            int mid = (lo + hi) / 2;

            if(v[mid] >= x)
                lo = mid;
            else
                hi = mid;
        }

        hcnt = lo - y + 1;

        cout << max(0, wcnt + hcnt - 1) << '\n';
    }
}
```
