### PR TITLE
[ajsthfldu] 2023. 11. 18

### DIFF
--- a/qsunki/baekjoon/14658.py
+++ b/qsunki/baekjoon/14658.py
@@ -1,0 +1,15 @@
+import sys
+
+n, m, l, k = map(int, sys.stdin.readline().split())
+stars = [list(map(int, sys.stdin.readline().split())) for _ in range(k)]
+max_cnt = 0
+
+for star1 in stars:
+    for star2 in stars:
+        cnt = 0
+        for star in stars:
+            if star1[0] <= star[0] <= star1[0] + l and star2[1] <= star[1] <= star2[1] + l:
+                cnt += 1
+        max_cnt = max(max_cnt, cnt)
+
+print(k - max_cnt)


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/14658

## 🚿 풀이
n과 m은 500,000 l은 100,000 이내인데 k는 1~100이기 때문에 별을 기준으로 완전탐색을 하면 된다.
트램펄린의 왼쪽 상단이 될 수 있는 점을 찾고 트램펄린 범위 안에 들어오는 별의 수를 센다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` python
import sys

n, m, l, k = map(int, sys.stdin.readline().split())
stars = [list(map(int, sys.stdin.readline().split())) for _ in range(k)]
max_cnt = 0

for star1 in stars:
    for star2 in stars:
        cnt = 0
        for star in stars:
            if star1[0] <= star[0] <= star1[0] + l and star2[1] <= star[1] <= star2[1] + l:
                cnt += 1
        max_cnt = max(max_cnt, cnt)

print(k - max_cnt)

```
