### PR TITLE
[qsunki] 2023. 11. 19

### DIFF
--- a/qsunki/baekjoon/5547.py
+++ b/qsunki/baekjoon/5547.py
@@ -1,0 +1,54 @@
+import sys
+from collections import deque
+
+
+def cnt_inner_wall(x, y):
+    queue = deque([(x, y)])
+    visited[y][x] = True
+    inner_wall_cnt = 0
+    is_open = False
+    while queue:
+        cx, cy = queue.popleft()
+        row = cy % 2
+        for i in range(6):
+            nx = cx + dx[row][i]
+            ny = cy + dy[i]
+            if nx < 0 or nx >= w or ny < 0 or ny >= h:
+                is_open = True
+                continue
+            if visited[ny][nx]:
+                continue
+            if view[ny][nx] == 1:
+                inner_wall_cnt += 1
+                continue
+            queue.append((nx, ny))
+            visited[ny][nx] = True
+    return 0 if is_open else inner_wall_cnt
+
+
+w, h = map(int, sys.stdin.readline().split())
+view = [[int(x) for x in sys.stdin.readline().split()] for _ in range(h)]
+# odd_row, even_row
+dx = [[0, -1, 0, 1, 1, 1], [-1, -1, -1, 0, 1, 0]]
+dy = [-1, 0, 1, 1, 0, -1]
+wall_cnt = 0
+inner_wall_cnt = 0
+visited = [[False] * w for _ in range(h)]
+
+for y in range(h):
+    for x in range(w):
+        if view[y][x] == 0:
+            if visited[y][x]:
+                continue
+            inner_wall_cnt += cnt_inner_wall(x, y)
+            continue
+        row = y % 2
+        for i in range(6):
+            ny = y + dy[i]
+            nx = x + dx[row][i]
+            if nx < 0 or nx >= w or ny < 0 or ny >= h:
+                wall_cnt += 1
+                continue
+            if view[ny][nx] == 0:
+                wall_cnt += 1
+print(wall_cnt - inner_wall_cnt)


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/5547

## 🚿 풀이
모든 벽의 갯수를 세고 둘러쌓인 공간의 벽 수를 빼주었다.
모든 벽을 셀 때는 완전탐색으로 하고 둘러쌓인 공간은 둘러 쌓여있는 지 확인하기 위해 bfs를 사용했다.

건물이 없는 곳에서의 벽면의 수를 bfs로 구하면 더 간단히 할 수 있는데 떠올리지 못했다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` python
import sys
from collections import deque


def cnt_inner_wall(x, y):
    queue = deque([(x, y)])
    visited[y][x] = True
    inner_wall_cnt = 0
    is_open = False
    while queue:
        cx, cy = queue.popleft()
        row = cy % 2
        for i in range(6):
            nx = cx + dx[row][i]
            ny = cy + dy[i]
            if nx < 0 or nx >= w or ny < 0 or ny >= h:
                is_open = True
                continue
            if visited[ny][nx]:
                continue
            if view[ny][nx] == 1:
                inner_wall_cnt += 1
                continue
            queue.append((nx, ny))
            visited[ny][nx] = True
    return 0 if is_open else inner_wall_cnt


w, h = map(int, sys.stdin.readline().split())
view = [[int(x) for x in sys.stdin.readline().split()] for _ in range(h)]
# odd_row, even_row
dx = [[0, -1, 0, 1, 1, 1], [-1, -1, -1, 0, 1, 0]]
dy = [-1, 0, 1, 1, 0, -1]
wall_cnt = 0
inner_wall_cnt = 0
visited = [[False] * w for _ in range(h)]

for y in range(h):
    for x in range(w):
        if view[y][x] == 0:
            if visited[y][x]:
                continue
            inner_wall_cnt += cnt_inner_wall(x, y)
            continue
        row = y % 2
        for i in range(6):
            ny = y + dy[i]
            nx = x + dx[row][i]
            if nx < 0 or nx >= w or ny < 0 or ny >= h:
                wall_cnt += 1
                continue
            if view[ny][nx] == 0:
                wall_cnt += 1
print(wall_cnt - inner_wall_cnt)

```
