### PR TITLE
[ajsthfldu] 2023. 11. 24

### DIFF
--- a/qsunki/baekjoon/12764.py
+++ b/qsunki/baekjoon/12764.py
@@ -1,0 +1,24 @@
+import sys
+from heapq import *
+
+n = int(sys.stdin.readline())
+times = [list(map(int, sys.stdin.readline().split())) for _ in range(n)]
+times.sort()
+seat_cnt = [0] * 100000
+computer_cnt = 0
+computer_queue = []
+end_queue = []
+for start, end in times:
+    while computer_queue and start > computer_queue[0][0]:
+        heappush(end_queue, tuple(reversed(heappop(computer_queue))))
+    if end_queue:
+        seat_num, _ = heappop(end_queue)
+        heappush(computer_queue, (end, seat_num))
+        seat_cnt[seat_num] += 1
+    else:
+        heappush(computer_queue, (end, computer_cnt))
+        seat_cnt[computer_cnt] += 1
+        computer_cnt += 1
+
+print(computer_cnt)
+print(*seat_cnt[:computer_cnt])


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/12764

## 🚿 풀이
시작시간이 빠른 것부터 computer_queue에 종료시간과 좌석번호를 넣고 뺄 때는 종료시간이 빠른 것부터 꺼낸다. end_queue에는 종료된 좌석번호를 넣는다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` python
import sys
from heapq import *

n = int(sys.stdin.readline())
times = [list(map(int, sys.stdin.readline().split())) for _ in range(n)]
times.sort()
seat_cnt = [0] * 100000
computer_cnt = 0
computer_queue = []
end_queue = []
for start, end in times:
    while computer_queue and start > computer_queue[0][0]:
        heappush(end_queue, tuple(reversed(heappop(computer_queue))))
    if end_queue:
        seat_num, _ = heappop(end_queue)
        heappush(computer_queue, (end, seat_num))
        seat_cnt[seat_num] += 1
    else:
        heappush(computer_queue, (end, computer_cnt))
        seat_cnt[computer_cnt] += 1
        computer_cnt += 1

print(computer_cnt)
print(*seat_cnt[:computer_cnt])

```
