### PR TITLE
[BOJ] 12886: 돌 그룹

### DIFF
--- a/qsunki/baekjoon/12886.py
+++ b/qsunki/baekjoon/12886.py
@@ -1,0 +1,32 @@
+from collections import deque
+import sys
+
+
+def bfs(a, b, c):
+    q = deque([(a, b, c)])
+    visited[a][c] = True
+    while q:
+        x, y, z = q.popleft()
+        if x == y == z:
+            return 1
+        for a, b in (x, y), (y, z), (x, z):
+            if a == b:
+                continue
+            b = b - a
+            a = a * 2
+            c = sum_ - a - b
+            a, b, c = sorted([a, b, c])
+            if visited[a][c]:
+                continue
+            q.append((a, b, c))
+            visited[a][c] = True
+    return 0
+
+
+a, b, c = sorted(map(int, sys.stdin.readline().split()))
+sum_ = a + b + c
+visited = [[False] * (sum_ + 1) for _ in range(sum_ + 1)]
+ans = 0
+if sum_ % 3 == 0:
+    ans = bfs(a, b, c)
+print(ans)


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/12886

## 🚿 풀이
3개의 돌 그룹 중에 2개를 선택해 bfs를 한다. 2개만 골라도 1개는 정해지기 때문
정렬을 해주면 좀 더 빠르다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` python
from collections import deque
import sys


def bfs(a, b, c):
    q = deque([(a, b, c)])
    visited[a][c] = True
    while q:
        x, y, z = q.popleft()
        if x == y == z:
            return 1
        for a, b in (x, y), (y, z), (x, z):
            if a == b:
                continue
            b = b - a
            a = a * 2
            c = sum_ - a - b
            a, b, c = sorted([a, b, c])
            if visited[a][c]:
                continue
            q.append((a, b, c))
            visited[a][c] = True
    return 0


a, b, c = sorted(map(int, sys.stdin.readline().split()))
sum_ = a + b + c
visited = [[False] * (sum_ + 1) for _ in range(sum_ + 1)]
ans = 0
if sum_ % 3 == 0:
    ans = bfs(a, b, c)
print(ans)

```
