### PR TITLE
[BOJ] 1464: 뒤집기 3

### DIFF
--- a/qsunki/baekjoon/1464.cpp
+++ b/qsunki/baekjoon/1464.cpp
@@ -1,0 +1,31 @@
+#include <iostream>
+#include <algorithm>
+#include <cstring>
+#include <deque>
+
+using namespace std;
+using ll = long long;
+using pii = pair<int, int>;
+
+int cnt_score[101];
+
+int main() {
+    ios_base::sync_with_stdio(false);
+    cin.tie(nullptr);
+    string s;
+    cin >> s;
+    deque<char> dq;
+    dq.push_front(s[0]);
+    for (int i = 1; i < s.length(); ++i) {
+         if (s[i] <= dq[0]) {
+             dq.push_front(s[i]);
+         } else {
+             dq.push_back(s[i]);
+         }
+    }
+    for (auto c : dq) {
+        cout << c;
+    }
+
+    return 0;
+}


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/1464

## 🚿 풀이
사전순으로 앞서기 위해서는 앞서는 문자가 앞으로 오도록 해야한다.
1. i번째 문자가 i - 1까지 진행했을 때의 첫 번째 문자보다 앞선다면 i - 1번째에서의 행동을 반대로 했어야하고 i번째에서 뒤집어야한다.
2. i번째 문자가 i - 1까지 진행했을 때의 첫 번째 문자보다 뒤진다면 i번째에서는 뒤집지 않으면 된다.
1번의 경우는 결과적으로 i - 1번째 진행했을 때의 결과의 맨 앞에 i번째 문자를 삽입하는 것이고
2번의 경우는 맨 뒤에 i번째 문자를 삽입하는 것과 같다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` c++
#include <iostream>
#include <algorithm>
#include <cstring>
#include <deque>

using namespace std;
using ll = long long;
using pii = pair<int, int>;

int cnt_score[101];

int main() {
    ios_base::sync_with_stdio(false);
    cin.tie(nullptr);
    string s;
    cin >> s;
    deque<char> dq;
    dq.push_front(s[0]);
    for (int i = 1; i < s.length(); ++i) {
         if (s[i] <= dq[0]) {
             dq.push_front(s[i]);
         } else {
             dq.push_back(s[i]);
         }
    }
    for (auto c : dq) {
        cout << c;
    }

    return 0;
}

```
