### PR TITLE
[BOJ 28359: 수열의 가치

### DIFF
--- a/qsunki/baekjoon/28359.java
+++ b/qsunki/baekjoon/28359.java
@@ -1,0 +1,31 @@
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Main {
+	public static void main(String[] args) throws IOException {
+		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+		StringBuilder sb = new StringBuilder();
+		int n = Integer.parseInt(br.readLine());
+		int[] cnts = new int[n + 1];
+		String[] line = br.readLine().split(" ");
+		int maxNum = 0;
+		for (int i = 0; i < n; ++i) {
+			int num = Integer.parseInt(line[i]);
+			++cnts[num];
+			if (maxNum * cnts[maxNum] < num * cnts[num]) {
+				maxNum = num;
+			}
+		}
+		int ans = maxNum * cnts[maxNum];
+		for (int i = 1; i <= n; ++i) {
+			for (int j = 0; j < cnts[i]; ++j) {
+				sb.append(i).append(" ");
+				ans += i;
+			}
+		}
+		System.out.println(ans);
+		System.out.println(sb);
+	}
+
+}


### PR DESCRIPTION
## ✈️ 문제
<!-- 여기에 문제 링크 다세요. -->
https://www.acmicpc.net/problem/28359

## 🚿 풀이
감소하지 않는 부분수열의 모든 원소와 증가하지 않는 부분수열의 모든 원소에 대해서 생각해볼 때 두 부분수열의 합이 가장 클 때는 '등장횟수 * 원소' 가 가장 큰 원소는 감소하지 않는 부분수열과 증가하지 않는 부분수열 모두에 포함되고 다른 원소들은 둘 중 하나에만 포함된다.
원소들의 배치 상태는 여러가지 경우가 있는데 오름차순 정렬 시 모든 원소가 감소하지 않는 부분수열에 들어가고 증가하지 않는 부분수열에는 '등장횟수 * 원소'가 가장 큰 원소만 포함이 된다.

여기서는 정렬 시 계수정렬을 사용했다.

## ⌨️ 코드
<!-- (```) 사이에 코드 복사하세요 -->

``` java
import java.io.BufferedReader;
import java.io.IOException;
import java.io.InputStreamReader;

public class Main {
	public static void main(String[] args) throws IOException {
		BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
		StringBuilder sb = new StringBuilder();
		int n = Integer.parseInt(br.readLine());
		int[] cnts = new int[n + 1];
		String[] line = br.readLine().split(" ");
		int maxNum = 0;
		for (int i = 0; i < n; ++i) {
			int num = Integer.parseInt(line[i]);
			++cnts[num];
			if (maxNum * cnts[maxNum] < num * cnts[num]) {
				maxNum = num;
			}
		}
		int ans = maxNum * cnts[maxNum];
		for (int i = 1; i <= n; ++i) {
			for (int j = 0; j < cnts[i]; ++j) {
				sb.append(i).append(" ");
				ans += i;
			}
		}
		System.out.println(ans);
		System.out.println(sb);
	}

}
```
